### PR TITLE
st2auth handler - Constrain split on : to first instance

### DIFF
--- a/st2auth/st2auth/handlers.py
+++ b/st2auth/st2auth/handlers.py
@@ -148,7 +148,7 @@ class StandaloneAuthHandler(AuthHandlerBase):
             abort_request()
             return
 
-        split = auth_value.split(':')
+        split = auth_value.split(':', 1)
         if len(split) != 2:
             LOG.audit('Invalid authorization header', extra=extra)
             abort_request()


### PR DESCRIPTION
When a user password contains `:` the authorisation fails because the split breaks the string into list with more than 2 elements.  Adding 1 to the split constrains it to the first occurrence of the `:`.  Caveat, this will still break if the users name contains a `:`.