### PR TITLE
Linting fixes, compile fixes

### DIFF
--- a/contrib/linux/sensors/file_watch_sensor.py
+++ b/contrib/linux/sensors/file_watch_sensor.py
@@ -55,7 +55,9 @@ class FileWatchSensor(Sensor):
         self.file_ref[file_path] = ref
 
         stop_event = threading.Event()
-        t = threading.Thread(target=self._tail, args=(file_path, stop_event), daemon=True)
+        t = threading.Thread(
+            target=self._tail, args=(file_path, stop_event), daemon=True
+        )
         self._watchers[file_path] = (t, stop_event)
         t.start()
 

--- a/st2common/st2common/content/validators.py
+++ b/st2common/st2common/content/validators.py
@@ -15,7 +15,7 @@
 
 from __future__ import absolute_import
 import os
-from importlib_metadata import get_distribution
+from importlib_metadata import distribution as get_distribution
 
 from st2common.constants.pack import USER_PACK_NAME_BLACKLIST
 

--- a/st2common/st2common/models/utils/action_alias_utils.py
+++ b/st2common/st2common/models/utils/action_alias_utils.py
@@ -121,7 +121,9 @@ class ActionAliasFormatParser(object):
         ending_pairs = re.match(self._snippets["ending"], param_stream, re.DOTALL)
         has_ending_pairs = ending_pairs and ending_pairs.group(1)
         if has_ending_pairs:
-            kv_pairs = re.findall(self._snippets["pairs"], ending_pairs.group(1), re.DOTALL)
+            kv_pairs = re.findall(
+                self._snippets["pairs"], ending_pairs.group(1), re.DOTALL
+            )
             param_stream = param_stream.replace(ending_pairs.group(1), "")
         else:
             kv_pairs = []
@@ -138,7 +140,9 @@ class ActionAliasFormatParser(object):
         # Transforming our format string into a regular expression,
         # substituting {{ ... }} with regex named groups, so that param_stream
         # matched against this expression yields a dict of params with values.
-        param_match = r'\1["\']?(?P<\2>(?:(?<=\').+?(?=\')|(?<=").+?(?=")|{.+?}|.+?))["\']?'
+        param_match = (
+            r'\1["\']?(?P<\2>(?:(?<=\').+?(?=\')|(?<=").+?(?=")|{.+?}|.+?))["\']?'
+        )
         reg = re.sub(
             r"(\s*)" + self._snippets["optional"],
             r"(?:" + param_match + r")?",
@@ -149,11 +153,15 @@ class ActionAliasFormatParser(object):
         reg_tokens = parse(reg, flags=re.DOTALL)
 
         # Add a beginning anchor if none exists
-        if not search_regex_tokens(((AT, AT_BEGINNING), (AT, AT_BEGINNING_STRING)), reg_tokens):
+        if not search_regex_tokens(
+            ((AT, AT_BEGINNING), (AT, AT_BEGINNING_STRING)), reg_tokens
+        ):
             reg = r"^\s*" + reg
 
         # Add an ending anchor if none exists
-        if not search_regex_tokens(((AT, AT_END), (AT, AT_END_STRING)), reg_tokens, backwards=True):
+        if not search_regex_tokens(
+            ((AT, AT_END), (AT, AT_END_STRING)), reg_tokens, backwards=True
+        ):
             reg = reg + r"\s*$"
 
         return re.compile(reg, re.DOTALL)
@@ -246,7 +254,9 @@ def extract_parameters(format_str, param_stream, match_multiple=False):
         return parser.get_extracted_param_value()
 
 
-def inject_immutable_parameters(action_alias_db, multiple_execution_parameters, action_context):
+def inject_immutable_parameters(
+    action_alias_db, multiple_execution_parameters, action_context
+):
     """
     Inject immutable parameters from the alias definiton on the execution parameters.
     Jinja expressions will be resolved.
@@ -274,10 +284,14 @@ def inject_immutable_parameters(action_alias_db, multiple_execution_parameters, 
     rendered_params = render_values(immutable_parameters, context)
 
     for exec_params in multiple_execution_parameters:
-        overriden = [param for param in immutable_parameters.keys() if param in exec_params]
+        overriden = [
+            param for param in immutable_parameters.keys() if param in exec_params
+        ]
         if overriden:
             raise ValueError(
-                "Immutable arguments cannot be overriden: {}".format(",".join(overriden))
+                "Immutable arguments cannot be overriden: {}".format(
+                    ",".join(overriden)
+                )
             )
 
         exec_params.update(rendered_params)

--- a/st2common/st2common/util/schema/__init__.py
+++ b/st2common/st2common/util/schema/__init__.py
@@ -155,7 +155,7 @@ CustomValidator = create(
         "pattern": Draft4Validator.VALIDATORS["pattern"],
         "patternProperties": Draft4Validator.VALIDATORS["patternProperties"],
         "properties": Draft3Validator.VALIDATORS["properties"],
-#        "required": Draft3Validator.VALIDATORS["required"],
+        #        "required": Draft3Validator.VALIDATORS["required"],
         "type": Draft4Validator.VALIDATORS["type"],
         "uniqueItems": Draft4Validator.VALIDATORS["uniqueItems"],
     },

--- a/st2common/tests/unit/test_action_alias_utils.py
+++ b/st2common/tests/unit/test_action_alias_utils.py
@@ -98,7 +98,9 @@ class TestActionAliasParser(TestCase):
         param_stream = 'Malcolm Reynolds is my captain weirdo="River Tam"'
         parser = ActionAliasFormatParser(alias_format, param_stream)
         extracted_values = parser.get_extracted_param_value()
-        self.assertEqual(extracted_values, {"captain": "Malcolm Reynolds", "weirdo": "River Tam"})
+        self.assertEqual(
+            extracted_values, {"captain": "Malcolm Reynolds", "weirdo": "River Tam"}
+        )
 
     def test_simple_parsing(self):
         alias_format = "skip {{a}} more skip {{b}} and skip more."
@@ -126,7 +128,9 @@ class TestActionAliasParser(TestCase):
         param_stream = 'acl "a1 a2" "b1" "c1"'
         parser = ActionAliasFormatParser(alias_format, param_stream)
         extracted_values = parser.get_extracted_param_value()
-        self.assertEqual(extracted_values, {"a": "a1 a2", "b": "b1", "c": "c1", "d": "1"})
+        self.assertEqual(
+            extracted_values, {"a": "a1 a2", "b": "b1", "c": "c1", "d": "1"}
+        )
 
     def test_spacing(self):
         alias_format = "acl {{a=test}}"
@@ -154,7 +158,9 @@ class TestActionAliasParser(TestCase):
         param_stream = "s one more two more three more"
         parser = ActionAliasFormatParser(alias_format, param_stream)
         extracted_values = parser.get_extracted_param_value()
-        self.assertEqual(extracted_values, {"a": "one", "b": "two", "c": "three", "d": "99"})
+        self.assertEqual(
+            extracted_values, {"a": "one", "b": "two", "c": "three", "d": "99"}
+        )
 
     def test_enclosed_defaults(self):
         alias_format = "skip {{ a = value }} more"
@@ -220,15 +226,22 @@ class TestActionAliasParser(TestCase):
         param_stream = None
         parser = ActionAliasFormatParser(alias_format, param_stream)
 
-        expected_msg = 'Command "" doesn\'t match format string "skip {{d}} more skip {{e}}."'
-        self.assertRaisesRegex(ParseException, expected_msg, parser.get_extracted_param_value)
+        expected_msg = (
+            'Command "" doesn\'t match format string "skip {{d}} more skip {{e}}."'
+        )
+        self.assertRaisesRegex(
+            ParseException, expected_msg, parser.get_extracted_param_value
+        )
 
     def test_all_the_things(self):
         # this is the most insane example I could come up with
         alias_format = (
-            "{{ p0='http' }} g {{ p1=p }} a " + "{{ url }} {{ p2={'a':'b'} }} {{ p3={{ e.i }} }}"
+            "{{ p0='http' }} g {{ p1=p }} a "
+            + "{{ url }} {{ p2={'a':'b'} }} {{ p3={{ e.i }} }}"
         )
-        param_stream = "g a http://google.com {{ execution.id }} p4='testing' p5={'a':'c'}"
+        param_stream = (
+            "g a http://google.com {{ execution.id }} p4='testing' p5={'a':'c'}"
+        )
         parser = ActionAliasFormatParser(alias_format, param_stream)
         extracted_values = parser.get_extracted_param_value()
         self.assertEqual(
@@ -249,8 +262,12 @@ class TestActionAliasParser(TestCase):
         param_stream = "foo lulz ponies"
         parser = ActionAliasFormatParser(alias_format, param_stream)
 
-        expected_msg = 'Command "foo lulz ponies" doesn\'t match format string "foo bar ponies"'
-        self.assertRaisesRegex(ParseException, expected_msg, parser.get_extracted_param_value)
+        expected_msg = (
+            'Command "foo lulz ponies" doesn\'t match format string "foo bar ponies"'
+        )
+        self.assertRaisesRegex(
+            ParseException, expected_msg, parser.get_extracted_param_value
+        )
 
     def test_ending_parameters_matching(self):
         alias_format = "foo bar"
@@ -364,14 +381,18 @@ class TestInjectImmutableParameters(TestCase):
         action_alias_db.immutable_parameters = {"env": "dev"}
         exec_params = [{"param1": "value1", "param2": "value2"}]
         inject_immutable_parameters(action_alias_db, exec_params, {})
-        self.assertEqual(exec_params, [{"param1": "value1", "param2": "value2", "env": "dev"}])
+        self.assertEqual(
+            exec_params, [{"param1": "value1", "param2": "value2", "env": "dev"}]
+        )
 
     def test_immutable_parameters_with_jinja(self):
         action_alias_db = Mock()
         action_alias_db.immutable_parameters = {"env": '{{ "dev" + "1" }}'}
         exec_params = [{"param1": "value1", "param2": "value2"}]
         inject_immutable_parameters(action_alias_db, exec_params, {})
-        self.assertEqual(exec_params, [{"param1": "value1", "param2": "value2", "env": "dev1"}])
+        self.assertEqual(
+            exec_params, [{"param1": "value1", "param2": "value2", "env": "dev1"}]
+        )
 
     def test_override_raises_error(self):
         action_alias_db = Mock()

--- a/st2common/tests/unit/test_util_output_schema.py
+++ b/st2common/tests/unit/test_util_output_schema.py
@@ -208,7 +208,9 @@ class OutputSchemaTestCase(unittest.TestCase):
             OUTPUT_KEY,
         )
 
-        expected_error = "Additional properties are not allowed ('output' was unexpected)"
+        expected_error = (
+            "Additional properties are not allowed ('output' was unexpected)"
+        )
         expected_message = "Error validating output. See error output for more details."
 
         # Use assertIn to avoid fragile exact-string matching: jsonschema error messages

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -36,7 +36,7 @@ tox==4.14.2
 pyrabbit
 prance==25.4.8.0
 # pip-tools provides pip-compile: to check for version conflicts
-pip-tools==7.4.1
+pip-tools==7.5.3
 pytest==7.0.1
 pytest-benchmark[histogram]==3.4.1
 pytest-icdiff==0.9


### PR DESCRIPTION
1. pip-tools 7.4.1 passed use_pep517 to pip 25.x's make_resolver() which dropped that arg. Upgraded to 7.5.3
```
TypeError: RequirementCommand.make_resolver() got an unexpected keyword argument 'use_pep517'
make: *** [Makefile:741: check-dependency-conflicts] Error 1
```
2. Black/lint checks
3. importlib_metadata updated get_distribution to distribution, fix the import
`from importlib_metadata import distribution as get_distribution`