### PR TITLE
More pip/setuptools install fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -253,6 +253,7 @@ check-python-packages:
 	@echo "================== CHECK PYTHON PACKAGES ===================="
 	@echo ""
 	test -f $(VIRTUALENV_COMPONENTS_DIR)/bin/activate || $(PYTHON_VERSION) -m venv $(VIRTUALENV_COMPONENTS_DIR) --system-site-packages
+	$(VIRTUALENV_COMPONENTS_DIR)/bin/pip install --quiet "setuptools==$(SETUPTOOLS_VERSION)"
 	@for component in $(COMPONENTS_WITHOUT_ST2TESTS); do \
 		echo "==========================================================="; \
 		echo "Checking component:" $$component; \
@@ -269,7 +270,7 @@ check-python-packages-nightly:
 	@echo ""
 
 	test -f $(VIRTUALENV_COMPONENTS_DIR)/bin/activate || $(PYTHON_VERSION) -m venv $(VIRTUALENV_COMPONENTS_DIR) --system-site-packages
-	$(VIRTUALENV_COMPONENTS_DIR)/bin/pip install wheel
+	$(VIRTUALENV_COMPONENTS_DIR)/bin/pip install --quiet "setuptools==$(SETUPTOOLS_VERSION)" wheel
 	@for component in $(COMPONENTS_WITHOUT_ST2TESTS); do \
 		echo "==========================================================="; \
 		echo "Checking component:" $$component; \

--- a/scripts/github/prepare-integration.sh
+++ b/scripts/github/prepare-integration.sh
@@ -27,7 +27,7 @@ echo ""
 
 # install st2 client
 if [ ! -x "${VIRTUALENV_DIR}/bin/st2" ] || ! st2 --version >/dev/null 2>&1; then
-    python ./st2client/setup.py develop
+    pip install -e ./st2client
 fi
 st2 --version
 


### PR DESCRIPTION

  - Lint (Python 3.12) — check-python-packages and check-python-packages-nightly failed with ModuleNotFoundError: No module named 'setuptools'. Python 3.12 venvs and setuptools 80 no longer include setuptools by default. Fixed by explicitly installing the pinned setuptools==$(SETUPTOOLS_VERSION) into the components venv after creation.
  - .ci-prepare-integration is failing to install st2client (in tons of tests) because `python ./st2client/setup.py develop `delegates internally to `pip install -e . --use-pep517` which no longer works on pip 25+
  ```
  Traceback (most recent call last):
  File "/home/runner/work/st2/st2/./st2client/setup.py", line 37, in <module>
    setup(
....
subprocess.CalledProcessError: Command '['/home/runner/work/st2/st2/virtualenv/bin/python', '-m', 'pip', 'install', '-e', '.', '--use-pep517']' returned non-zero exit status 1.
make: *** [Makefile:1208: .ci-prepare-integration] Error 1
```