### PR TITLE
Fix broken pip version sed pattern for el9 rpm spec

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,7 +162,7 @@ jobs:
             echo "Patch PIP version used by dh_virtualenv"
             sed -ri "s/^PIP_VERSION .*$/PIP_VERSION = ${PIP_VERSION}/" packages/st2/debian/rules
             echo "Patch PIP version used by rpm spec"
-            sed -ri "s/install pip==[^\s]+/install pip==${PIP_VERSION}/" rpmspec/package_venv.spec
+            sed -ri "s/install pip==[^[:space:]]+/install pip==${PIP_VERSION}/" rpmspec/package_venv.spec
       - run:
           name: Initialize packages Build Environment
           command: |


### PR DESCRIPTION
`[^\s]` inside a sed bracket expression is not "non-whitespace" — backslash isn't special there, so it excludes the literal characters `\` and `s` instead. Since the target text contains `%{pipversion}`, the match stopped at the `s` in "version", leaving `sion}` unreplaced and producing corrupted output like `pip==26.1.2sion}`.

Use `[^[:space:]]+`, the POSIX class that actually means non-whitespace.


```
  Reproduce the bug (current/broken sed):
  PIP_VERSION=26.1.2
  gsed -ri "s/install pip==[^\s]+/install pip==${PIP_VERSION}/" rpmspec/package_venv.spec
  grep "install pip==" rpmspec/package_venv.spec
  Output:
  %define pin_pip %{venv_python} %{venv_bin}/%{pipbin} install pip==26.1.2sion}
  Matches the CI failure: ERROR: No matching distribution found for pip==26.1.2sion

  Verify the fix:
  PIP_VERSION=26.1.2
  gsed -ri "s/install pip==[^[:space:]]+/install pip==${PIP_VERSION}/" rpmspec/package_venv.spec
  grep "install pip==" rpmspec/package_venv.spec
  Output:
  %define pin_pip %{venv_python} %{venv_bin}/%{pipbin} install pip==26.1.2
  ```